### PR TITLE
Add ppc64le & s390x wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,26 @@ jobs:
           - PLAT=ppc64le
           - DOCKER_TEST_IMAGE=multibuild/xenial_ppc64le
           - MB_PYTHON_VERSION=3.9
+      - arch: s390x
+        env:
+          - PLAT=s390x
+          - DOCKER_TEST_IMAGE=multibuild/xenial_s390x
+          - MB_PYTHON_VERSION=3.6
+      - arch: s390x
+        env:
+          - PLAT=s390x
+          - DOCKER_TEST_IMAGE=multibuild/xenial_s390x
+          - MB_PYTHON_VERSION=3.7
+      - arch: s390x
+        env:
+          - PLAT=s390x
+          - DOCKER_TEST_IMAGE=multibuild/xenial_s390x
+          - MB_PYTHON_VERSION=3.8
+      - arch: s390x
+        env:
+          - PLAT=s390x
+          - DOCKER_TEST_IMAGE=multibuild/xenial_s390x
+          - MB_PYTHON_VERSION=3.9
 
 before_install:
     - sudo apt-get install mercurial

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ install:
 
 script:
     - install_run $PLAT
+
 after_success:
     - pip install twine
-    - twine upload ${TRAVIS_BUILD_DIR}/wheelhouse/*
+    - twine check ${TRAVIS_BUILD_DIR}/wheelhouse/*
+    - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then twine upload ${TRAVIS_BUILD_DIR}/wheelhouse/*; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 env:
     global:
         - REPO_DIR=cffi
-        - PLAT=aarch64
         - MB_ML_VER=2014
-        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
 
 language: generic
 services: docker
 os: linux
+dist: focal
 
 jobs:
   exclude:
@@ -16,15 +15,43 @@ jobs:
   include:
       - arch: arm64
         env:
+          - PLAT=aarch64
+          - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
           - MB_PYTHON_VERSION=3.6
       - arch: arm64
         env:
+          - PLAT=aarch64
+          - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
           - MB_PYTHON_VERSION=3.7
       - arch: arm64
         env:
+          - PLAT=aarch64
+          - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
           - MB_PYTHON_VERSION=3.8
       - arch: arm64
         env:
+          - PLAT=aarch64
+          - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+          - MB_PYTHON_VERSION=3.9
+      - arch: ppc64le
+        env:
+          - PLAT=ppc64le
+          - DOCKER_TEST_IMAGE=multibuild/xenial_ppc64le
+          - MB_PYTHON_VERSION=3.6
+      - arch: ppc64le
+        env:
+          - PLAT=ppc64le
+          - DOCKER_TEST_IMAGE=multibuild/xenial_ppc64le
+          - MB_PYTHON_VERSION=3.7
+      - arch: ppc64le
+        env:
+          - PLAT=ppc64le
+          - DOCKER_TEST_IMAGE=multibuild/xenial_ppc64le
+          - MB_PYTHON_VERSION=3.8
+      - arch: ppc64le
+        env:
+          - PLAT=ppc64le
+          - DOCKER_TEST_IMAGE=multibuild/xenial_ppc64le
           - MB_PYTHON_VERSION=3.9
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,6 @@ script:
     - install_run $PLAT
 
 after_success:
-    - pip install twine
+    - pip install twine "cryptography~=3.3.2"
     - twine check ${TRAVIS_BUILD_DIR}/wheelhouse/*
     - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then twine upload ${TRAVIS_BUILD_DIR}/wheelhouse/*; fi


### PR DESCRIPTION
I think it would probably be useful to have this package distribution also publish wheels for manylinux2014_s390x and manylinux2014_ppc64le.

IMHO, CFFI wheels are a must-have in order for package maintainers to be able to use those manylinux images (& future PEP 600 ones) without too much hassle since Twine has a dependency (indirect) on it.

